### PR TITLE
update deprecated java:8 image to openjdk:8

### DIFF
--- a/apache-traffic-server-exporter/Dockerfile
+++ b/apache-traffic-server-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM  java:8 
+FROM  openjdk:8 
 
 # Install maven
 RUN apt-get update  


### PR DESCRIPTION
This PR updates the deprecated java:8 image to openjdk:8 - https://stackoverflow.com/a/73497171

Attempting to build with java:8 gives this build error:
`failed to solve with frontend dockerfile.v0: failed to create LLB definition: docker.io/library/java:8: not found`